### PR TITLE
Keep track of HTTP Error responses and fix failing test

### DIFF
--- a/lib/requests.rb
+++ b/lib/requests.rb
@@ -4,7 +4,14 @@ require 'openssl'
 require 'uri'
 
 module Requests
-  Error = Class.new(StandardError)
+  class Error < StandardError
+    attr_reader :http_error
+
+    def initialize(http_error)
+      super(http_error.message)
+      @http_error = http_error
+    end
+  end
 
   CA_FILE = ENV.fetch('REQUESTS_CA_FILE',
                       File.expand_path('../cacert.pem', __FILE__))
@@ -29,7 +36,7 @@ module Requests
     if response.is_a?(Net::HTTPSuccess)
       Response.new(response.code, response.to_hash, response.body)
     else
-      raise Error, response.inspect
+      raise Error, response
     end
   end
 

--- a/tests/requests_test.rb
+++ b/tests/requests_test.rb
@@ -49,3 +49,11 @@ test 'POST params' do
   assert_equal form['b'], '3'
   assert_equal form['c'], '4'
 end
+
+test 'Error' do
+  begin
+    Requests.post('http://httpbin.org/something')
+  rescue Requests::Error => e
+    assert_equal Net::HTTPNotFound, e.http_error.class
+  end
+end


### PR DESCRIPTION
Hi cyx,

I'd like to have more granularity when answering to http errors so I added `http_error` to the `Requests::Error` class. This lets the client have different responses to statuses >= 400 without needing to parse the `Requests::Error` message
