### PR TITLE
Add support for HTTP proxies

### DIFF
--- a/lib/requests.rb
+++ b/lib/requests.rb
@@ -21,7 +21,8 @@ module Requests
     headers: {},
     data: nil,
     params: nil,
-    auth: nil)
+    auth: nil,
+    proxy: nil)
 
     uri = URI.parse(url)
     uri.query = encode_www_form(params) if params
@@ -30,7 +31,8 @@ module Requests
 
     basic_auth(headers, *auth) if auth
 
-    response = Net::HTTP.start(uri.host, uri.port, opts(uri)) do |http|
+    proxy = proxy.to_h.values_at(:host, :port, :user, :password)
+    response = Net::HTTP.start(uri.host, uri.port, *proxy, opts(uri)) do |http|
       http.send_request(method, uri, body, headers)
     end
 

--- a/tests/proxy_test.rb
+++ b/tests/proxy_test.rb
@@ -1,0 +1,32 @@
+require 'requests/sugar'
+require 'webrick'
+require 'webrick/httpproxy'
+require 'thread'
+require 'logger'
+
+port = ENV.fetch("PROXY_PORT", 8000)
+
+setup do
+  WEBrick::HTTPProxyServer.new(
+    ServerName: "0.0.0.0",
+    Port: port,
+    Logger: Logger.new("/dev/null"),
+    AccessLog: []
+  )
+end
+
+test 'request via proxy' do |proxy|
+  Thread.new { proxy.start }
+
+  r = Requests.get('http://httpbin.org/get', params: { foo: 'bar' }, proxy: {
+    host: '0.0.0.0', port: port
+  })
+
+  assert_equal 200, r.status
+  assert_equal ['application/json'], r.headers['content-type']
+  assert(r.json['args'] && r.json['args']['foo'] == 'bar')
+
+  assert_equal ["1.1 0.0.0.0:#{port}"], r.headers['via']
+
+  proxy.shutdown
+end


### PR DESCRIPTION
Support using an HTTP proxy by passing a `proxy` hash with the host, port, user, and password to authenticate against the proxy.
