### PR TITLE
Use raise_for_status to raise exception

### DIFF
--- a/tests/requests_test.rb
+++ b/tests/requests_test.rb
@@ -52,9 +52,10 @@ end
 
 test 'Error' do
   begin
-    Requests.post('http://httpbin.org/something')
+    r = Requests.post('http://httpbin.org/something')
+    r.raise_for_status
   rescue Requests::Error => e
-    assert_equal Net::HTTPNotFound, e.response.class
+    assert_equal 'Client Error: 404 NOT FOUND', e.response
   end
 end
 


### PR DESCRIPTION
When retcode is not 200, we still can get the content of the response. Raise exception initiatively will broken the api of getting response.